### PR TITLE
Added semicolon to fix build error

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Graph from './components/graph'
 
 export default class App extends React.Component {
-  state = { dataSetIndex: 0 }
+  state = { dataSetIndex: 0 };
 
   selectDataset(event) {
     this.setState({dataSetIndex: event.target.value});


### PR DESCRIPTION
Fix for this error, which occurs when trying to access the app in a
browser:

ERROR in ./scripts/app.js
Module build failed: SyntaxError:
/Users/seb/GitHub/react-svg-smashing/scripts/app.js: A semicolon is
required after a class property (5:29)
3 |
4 | export default class App extends React.Component {

> 5 |   state = { dataSetIndex: 0 }
> |                              ^
> 6 |
> 7 |   selectDataset(event) {
> 8 |     this.setState({dataSetIndex: event.target.value});
> at Parser.pp.raise
> (/Users/seb/GitHub/react-svg-smashing/node_modules/babel-core/node_modul
> es/babylon/index.js:1413:13)
